### PR TITLE
Update index.md to mention hidden folders

### DIFF
--- a/jailbreaking/WinterBreak/index.md
+++ b/jailbreaking/WinterBreak/index.md
@@ -24,7 +24,7 @@ It is based on [Mesquito](../../mesquito/)
 [Download WinterBreak](https://github.com/KindleModding/WinterBreak/releases/latest){: .btn .btn-purple}
 2. Turn on aeroplane mode on your Kindle
 3. Plug the Kindle into your computer
-4. Extract the contents of the `WinterBreak.tar.gz` file to your Kindle
+4. Extract the contents of the `WinterBreak.tar.gz` file to your Kindle ( Note: For Windows / macOS users , Ensure that hidden folders are also copied over )
 5. Eject your Kindle from your computer
 6. Reboot your Kindle
 7. Open the Kindle Store on your Kindle


### PR DESCRIPTION
If a user extracts the zip first and tried to copy files manually they might miss the hidden folders like `.active_content_sandbox` depending on their OS and File Manager configuration