### PR TITLE
docs: clarify messaging on installing hotfix will push update dialog

### DIFF
--- a/jailbreaking/post-jailbreak/setting-up-a-hotfix/index.md
+++ b/jailbreaking/post-jailbreak/setting-up-a-hotfix/index.md
@@ -46,7 +46,7 @@ If you installed OTARenamer, make sure to uninstall it beforehand or the hotfix 
         <div class="step">
             <h2>Confirming Hotfix Install</h2>
             <div class="stepContent">
-                <p>If asked, select <code>Update</code></p>
+                <p>If asked, select <code>Update</code>. You can expect this to install the hotfix, as an update.</p>
                 <br/>
                 <img src="./update_dialog.png" />
             </div>


### PR DESCRIPTION
As I was installing, I noticed the hotfix installed an update. It was unclear if that was the success or failure state, so clarifying in the docs.

feel free to edit or toss, or request changes