### PR TITLE
add note about pre-built toolchain release

### DIFF
--- a/kindle-dev/gtk-tutorial/prerequisites.md
+++ b/kindle-dev/gtk-tutorial/prerequisites.md
@@ -61,6 +61,9 @@ sudo apt-get install meson gtk2.0 libgtk2.0-dev
 
 ## Building The Toolchain
 
+{: .note}
+If you don't want to build the toolchain yourself or if you encounter difficulties in building it, use the [pre-built release](https://github.com/koreader/koxtoolchain/releases/latest)
+
 #### 1. Clone the toolchain
 ```sh
 git clone --recursive --depth=1 https://github.com/koreader/koxtoolchain.git


### PR DESCRIPTION
It would be helpful to mention that a pre-built toolchain release can be used.
Especially since it's currently impossible to build it on Arch Linux - https://github.com/koreader/koxtoolchain/issues/53