### PR TITLE
Add Guide for Preventing Automatic Updates by Filling Kindle Storage

### DIFF
--- a/jailbreaking/WinterBreak/index.md
+++ b/jailbreaking/WinterBreak/index.md
@@ -35,6 +35,9 @@ Winterbreak/Mesquito does NOT work on firmware `5.18.1` and beyond.
 {: .highlight}
 If you face any issues, please check the [troubleshooting](#troubleshooting) section
 
+{: .note}
+If your Kindle is running a firmware version lower than `5.18.1` and **is not yet registered**, make sure to follow [these steps to prevent your Kindle from automatically updating](../preventing-auto-update/) before registering your device with Amazon. This will help you avoid an automatic firmware update during the registration process.
+
 ## Installation Guide
 
 <div id="guide">

--- a/jailbreaking/post-jailbreak/installing-kual-mrpi/index.md
+++ b/jailbreaking/post-jailbreak/installing-kual-mrpi/index.md
@@ -80,5 +80,6 @@ You will need to install KUAL (Kindle Unified Application Launcher) and MRPI (Mo
 <script>new Guide("guide", "../disable-ota", "Disabling OTA Updates");</script>
 
 ## Troubleshooting
+- The installation of `Update_KUALBooklet_hotfix_*_install.bin` may fail if there is not enough free space on your Kindle. If you are using the "fill storage" method to block updates, make sure to free up some space before proceeding with these steps.
 - Verify the location of all the folders and files on the Kindle
 - Try copying the `Update_KUALBooklet_hotfix_*_install.bin` file to the root of your Kindle when connected to your PC, and then go to `Settings` > `Update Your Kindle`, then resume from `step 5`

--- a/jailbreaking/prevent-auto-update.md
+++ b/jailbreaking/prevent-auto-update.md
@@ -1,0 +1,118 @@
+---
+layout: default
+parent: Jailbreaking Your Kindle
+title: Prevent Automatic Updates
+nav_order: 99
+has_children: true
+---
+
+# Preventing Automatic Updates by Filling Kindle Storage
+
+## Why Fill the Kindle's Storage?
+
+Kindle devices can automatically download and install firmware updates when they have enough free storage space. These updates can block jailbreaking methods. Automatic updates may occur when:
+
+- You open the Kindle Store.
+- You register your Kindle to an Amazon account.
+- The device is connected to Wi-Fi, even briefly.
+- The Kindle is rebooted while connected to the internet.
+
+Filling the Kindle's storage (leaving only 20-50 MB free) prevents the device from downloading and installing updates, as the update process requires more free space.
+
+## How to Fill the Kindle's Storage
+
+You can use a simple script to fill your Kindle's storage with dummy files, leaving only a small amount of free space. This script is available in the [Kindle-Filler-Disk GitHub repository](https://github.com/bastianmarin/Kindle-Filler-Disk/) along with other useful scripts for Windows, macOS, and Linux.
+
+### Step-by-Step Tutorial
+
+#### 1. Put Your Kindle in Airplane Mode
+
+- On your Kindle, swipe down from the top to open Quick Actions.
+- Tap the **Airplane Mode** icon to enable it. This will disconnect Wi-Fi and prevent updates during the process.
+
+#### 2. Connect Your Kindle to Your Computer via USB
+
+- Use a USB cable to connect your Kindle to your computer.
+- Wait for the Kindle to appear as a USB drive.
+
+#### 3. Download the Disk Filler Script
+
+- Go to the [Kindle-Filler-Disk GitHub repository](https://github.com/bastianmarin/Kindle-Filler-Disk/).
+- Download the appropriate script for your operating system:
+  - **Windows:** `kindle_disk_filler.ps1`
+  - **macOS/Linux:** `kindle_disk_filler.sh`
+
+#### 4. Run the Script
+
+##### On Windows:
+
+- Copy `Filler.ps1` to the root directory of your Kindle (the main folder you see when you open the Kindle drive).
+- Open **PowerShell** in the folder containing `Filler.ps1`.  
+  - Tip: In File Explorer, hold **Shift** and right-click in the folder background, then select "Open PowerShell window here".
+  - Or, click the address bar, type `powershell`, and press Enter.
+- If you get an execution policy error, you can bypass it by running:
+  ```powershell
+  powershell -ExecutionPolicy Bypass -File .\Filler.ps1
+  ```
+  Or, for the current session only:
+  ```powershell
+  Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+  .\Filler.ps1
+  ```
+- Follow the on-screen prompts to select how much free space to leave (20 MB is recommended).
+- The script will create files in a folder called `fill_disk` on your Kindle until only the specified free space remains.
+
+##### On macOS/Linux:
+
+- Copy `Filler.sh` to the root directory of your Kindle (the main folder you see when you open the Kindle drive).
+- Open a terminal in the folder containing `Filler.sh`.
+- Make the script executable (if needed):
+  ```sh
+  chmod +x Filler.sh
+  ```
+- Run the script:
+  ```sh
+  ./Filler.sh
+  ```
+- Follow the on-screen prompts to select how much free space to leave (20 MB is recommended).
+- The script will create files in a folder called `fill_disk` on your Kindle until only the specified free space remains.
+
+#### 5. Safely Disconnect and Verify Storage
+
+- Eject your Kindle from your computer.
+- On your Kindle, go to **Settings > Device Options > Device Info** (or similar).
+- Check that the available storage is **20 MB or less**.
+
+#### 6. Register Your Kindle
+
+- With storage nearly full, connect to Wi-Fi and register your Kindle to your Amazon account.
+- The device will not be able to download updates due to lack of space.
+
+#### 7. Enable Airplane Mode Again
+
+- Immediately after registration, enable **Airplane Mode** to prevent any update attempts.
+- Proceed with the next jailbreak steps (such as WinterBreak).
+> **Important Note:** After filling your Kindle's storage, check its contents in the **main folder** (root directory) and delete any files ending with `.bin` or named `update.bin.tmp.partial`. These files are automatic update attempts by the Kindle and should be removed to prevent the device from trying to install an update when you free up space.
+
+---
+
+## After Jailbreak: Freeing Up Space
+
+Once you have completed the jailbreak process, you can safely delete the `fill_disk` folder to recover storage space. You may also remove only some of the files if you want to keep the disk nearly full for a while longer.
+
+- **Windows:**  
+  Open File Explorer and navigate to the folder containing `fill_disk`. Delete the `fill_disk` folder, or remove individual files inside it.
+
+- **Linux / macOS:**  
+  Open a terminal in the folder containing `fill_disk` and run:
+  ```sh
+  rm -rf fill_disk
+  ```
+  Or remove individual files as needed.
+
+This will restore your available disk space.
+
+
+---
+
+For more scripts and detailed guides, visit the [Kindle-Filler-Disk GitHub repository](https://github.com/bastianmarin/Kindle-Filler-Disk/).

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,39 @@
+# Kindle Modding Wiki
+
+## Getting Started
+
+This project is a static website built with [Jekyll](https://jekyllrb.com/) using the [just-the-docs](https://just-the-docs.com/) theme.
+
+### Prerequisites
+- [Ruby](https://www.ruby-lang.org/en/downloads/)
+- [Bundler](https://bundler.io/)
+
+### Installation
+1. **Install Bundler**
+   - Open a terminal (PowerShell or Command Prompt) and run:
+     ```sh
+     gem install bundler
+     ```
+2. **Install project dependencies**
+   - In the project directory, run:
+     ```sh
+     bundle install
+     ```
+
+## Development
+
+To run the site locally for development:
+
+1. In the project directory, start the Jekyll server:
+   ```sh
+   bundle exec jekyll serve
+   ```
+2. Open your browser and go to [http://localhost:4000](http://localhost:4000)
+
+The site will automatically reload when you save changes to files.
+
+## Troubleshooting
+- If you have problems installing the `wdm` gem on Windows, you can comment out or remove the `gem "wdm"` line in your `Gemfile`. This gem is optional and not required for the site to work.
+---
+
+For more information, see the [Jekyll documentation](https://jekyllrb.com/docs/).


### PR DESCRIPTION
This pull request adds a new documentation page explaining how to prevent automatic firmware updates on Kindle devices by filling the device’s storage. The new guide includes:

- An explanation of why filling the Kindle’s storage helps block automatic updates.
- Step-by-step instructions for using the Kindle-Filler-Disk scripts on Windows, macOS, and Linux.
- Tips for safely disconnecting the device and verifying available storage.
- Instructions for cleaning up after jailbreaking to recover storage space.
- Important notes on deleting any update files that may have been downloaded.