### PR TITLE
tell user to delete file ending in `.bin`

### DIFF
--- a/jailbreaking/post-jailbreak/disable-ota.md
+++ b/jailbreaking/post-jailbreak/disable-ota.md
@@ -67,7 +67,7 @@ Kindles automatically update when connected to WiFi, which despite a `hotfix`, c
                 <div class="version-block">
                     <p class="version-label">Firmware >=5.11.x:</p>
                     <p>Unzip and copy the <code>renameotabin</code> folder to the <code>extensions</code> folder on your Kindle</p>
-                    <p class="warning">Delete any file with a name similar to <code>update.bin.tmp.partial</code> from your Kindle to prevent an automatic update</p>
+                    <p class="warning">Delete any file with a name similar to <code>update.bin.tmp.partial</code> or ending in <code>.bin</code> from your Kindle to prevent an automatic update</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
learned this one the hard way. I noticed a file had been created ending in `.bin` between plugging in my kindle which from a previous step I knew might have been an update but this is my first time doing this so I wasn't sure it was just created by the mod. turns out it wasn't