### PR TITLE
Re-writes and re-directs #4

### DIFF
--- a/jailbreaking/WinterBreak/index.md
+++ b/jailbreaking/WinterBreak/index.md
@@ -23,10 +23,6 @@ It is based on [Mesquito](../../mesquito/)
 > <br/>
 > RIP the original deadlines
 
-{: .warning}
-Winterbreak/Mesquito does NOT work on firmware `5.18.1` and beyond.
-
-
 ## Prerequisites
 - You will need a PC
 - Your Kindle must be registered
@@ -35,9 +31,6 @@ Winterbreak/Mesquito does NOT work on firmware `5.18.1` and beyond.
 
 {: .highlight}
 If you face any issues, please check the [troubleshooting](#troubleshooting) section
-
-{: .note}
-If your Kindle is running a firmware version lower than `5.18.1` and **is not yet registered**, make sure to follow [these steps to prevent your Kindle from automatically updating](../prevent-auto-update.html) before registering your device with Amazon. This will help you avoid an automatic firmware update during the registration process.
 
 ## Installation Guide
 
@@ -52,6 +45,12 @@ If your Kindle is running a firmware version lower than `5.18.1` and **is not ye
             <h2>Download the latest WinterBreak release:</h2>
             <div class="stepContent">
                 <a href="https://github.com/KindleModding/WinterBreak/releases/latest/download/WinterBreak.tar.gz" class="btn btn-purple">Download</a>
+                <p class="note">
+                    If your Kindle is <b>is not yet registered</b>, make sure to follow <a href="../prevent-auto-update.html">these steps to prevent your Kindle from automatically updating</a> before registering your device with Amazon. This will help you avoid an automatic firmware update during the registration process
+                </p>
+                <p class="warning">
+                    Winterbreak/Mesquito does NOT work on firmware <code>5.18.1</code> and beyond
+                </p>
             </div>
         </div>
         <div class="step">
@@ -91,7 +90,7 @@ If your Kindle is running a firmware version lower than `5.18.1` and **is not ye
         <div class="step">
             <h2>Running WinterBreak</h2>
             <div class="stepContent">
-                <p>Once Mesquito has loaded, re-enable Airplane mode and click on the WinterBreak icon</p>
+                <p>Once Mesquito has loaded, click on the WinterBreak icon</p>
                 <img src="./winterbreak_launcher.png" />
             </div>
         </div>
@@ -99,7 +98,7 @@ If your Kindle is running a firmware version lower than `5.18.1` and **is not ye
             <h2>Done</h2>
             <div class="stepContent">
                 <p>Wait around 30 seconds, and your Kindle will say something along the lines of "Now you are ready to install the hotfix"</p>
-                <p>If no funky text appears, retry the guide again with Airplane mode off. Once it does, turn Airplane mode back on and continue to the post-jailbreak stage
+                <p>If no funky text appears, retry the guide again. Once it does, <b>turn Airplane mode back on</b> and continue to the post-jailbreak stage
                 </p>
                 <p class="warning">
                     If present, delete the <code>update.bin.tmp.partial</code> file from your device to prevent an automatic update
@@ -117,20 +116,10 @@ If your Kindle is running a firmware version lower than `5.18.1` and **is not ye
 <script>new Guide("guide", "../post-jailbreak/setting-up-a-hotfix", "Setting Up A Hotfix");</script>
 
 # Troubleshooting
-## Kindle Store encountered an unexpected error
-> Faced this error and found a solution [DiabloSat](https://github.com/progzone122) & [Rexathion1](https://github.com/Rexathion1)
 
 If an **“Unexpected error”** occurs when you try to log in to the Kindle Store or **only the Kindle Store home page** is displayed, try the following solutions:
 
-1. Factory Reset your Kindle
-2. Before registering - plug your Kindle into your PC, move the WinterBreak files to the root of your storage space
-3. Login to your account, and enable Airplane mode as soon as possible
-4. Connect your Kindle into your PC and delete the cache directory at the path `.active_content_sandbox/store/resource/LocalStorage` (skip this step if the `LocalStorage` directory does not exist)
-5. Reboot your Kindle
-6. Open the Kindle Store on your Kindle
-7. When prompted, click `Yes` to turn off Airplane mode
-
-### Alternative solution
+### LocalStorage Replacement
 
 1. After successfully registered, plug your Kindle into your PC and delete the `.active_content_sandbox` folder,  make sure to also delete any files with a name similar to `update.bin.tmp.partial` from your Kindle to prevent an automatic update
 2. Reboot your Kindle
@@ -140,6 +129,18 @@ If an **“Unexpected error”** occurs when you try to log in to the Kindle Sto
 6. Delete the cache directory in the path `.active_content_sandbox/store/resource/LocalStorage`. If this folder has not yet been generated, browse the Kindle Store for another couple of minutes until it is generated. Make sure to always delete the previously mentioned `update.bin.tmp.partial` file, especially before any rebooting
 7. Once deleted, copy the Winterbreak files to your Kindle and reboot
 8. Open the Kindle Store on your Kindle, when prompted, click `Yes` to turn off Airplane mode
+
+### Factory Reset
+> Faced this error and found a solution [DiabloSat](https://github.com/progzone122) & [Rexathion1](https://github.com/Rexathion1)
+
+1. Factory Reset your Kindle
+2. Before registering - plug your Kindle into your PC, move the WinterBreak files to the root of your storage space
+3. Login to your account, and enable Airplane mode as soon as possible
+4. Connect your Kindle into your PC and delete the cache directory at the path `.active_content_sandbox/store/resource/LocalStorage` (skip this step if the `LocalStorage` directory does not exist)
+5. Reboot your Kindle
+6. Open the Kindle Store on your Kindle
+7. When prompted, click `Yes` to turn off Airplane mode
+
 
 # Special Thanks To Our Courageous Beta Testers
 - Crystals (Bricked their PW4 testing)

--- a/jailbreaking/post-jailbreak/disable-ota.md
+++ b/jailbreaking/post-jailbreak/disable-ota.md
@@ -67,7 +67,7 @@ Kindles automatically update when connected to WiFi, which despite a `hotfix`, c
                 <div class="version-block">
                     <p class="version-label">Firmware >=5.11.x:</p>
                     <p>Unzip and copy the <code>renameotabin</code> folder to the <code>extensions</code> folder on your Kindle</p>
-                    <p class="warning">Delete any file with a name similar to <code>update.bin.tmp.partial</code> from your Kindle to prevent an automatic update</p>
+                    <p class="warning">Delete any file with a name similar to <code>update.bin.tmp.partial</code> or ending in <code>.bin</code> from your Kindle to prevent an automatic update</p>
                 </div>
             </div>
         </div>
@@ -119,7 +119,6 @@ Kindles automatically update when connected to WiFi, which despite a `hotfix`, c
                     <p>If you want to factory reset, downgrade or update your Kindle, you will <strong>need</strong> to restore the update binaries by opening KUAL, selecting <code>Rename OTA Binaries</code> and then selecting <code>Restore</code> instead of rename</p>
                 </div>
                 <p class="highlight">You can now safely turn off Airplane Mode and re-enable WiFi. Your Kindle will connect to the internet but will not download or install OTA updates.</p>
-                <p class="note">If you want to maintain access to the Kindle Store, check out the guide for <a href="re-enabling-the-store">Re-enabling the Store</a></p>
             </div>
         </div>
     </div>

--- a/jailbreaking/post-jailbreak/koreader.md
+++ b/jailbreaking/post-jailbreak/koreader.md
@@ -135,7 +135,7 @@ Your Kindle must be jailbroken and have MRPI and KUAL installed to be able to ru
 
 </style>
 
-<script>new Guide("guide");</script>
+<script>new Guide("guide", "../jailbreak-faq", "Jailbreak FAQ");</script>
 
 ## Credits
 

--- a/jailbreaking/post-jailbreak/re-enabling-the-store/index.md
+++ b/jailbreaking/post-jailbreak/re-enabling-the-store/index.md
@@ -62,7 +62,8 @@ Ensure you've [disabled OTA Updates](../disable-ota) before re-enabling the stor
         <button class="btn btn-green" id="next">Next Step</button>
     </div>
 </div>
-<script>new Guide("guide");</script>
+
+<script>new Guide("guide", "../koreader", "Install KOReader");</script>
 
 ## Troubleshooting
 

--- a/jailbreaking/prevent-auto-update.md
+++ b/jailbreaking/prevent-auto-update.md
@@ -22,14 +22,16 @@ Filling the Kindle's storage (leaving only 50-200 MB free) prevents the device f
 ## How to Fill the Kindle's Storage
 
 {: .warning}
-> Delete update-whatever.bin OR update.partial.bin, and turn on Airplane Mode!
+> Delete `update-whatever.bin` OR `update.partial.bin`, and turn on Airplane Mode!
 
 You can use a simple script to fill your Kindle's storage with dummy files, leaving only a small amount of free space. This script is available in the [Kindle-Filler-Disk GitHub repository](https://github.com/bastianmarin/Kindle-Filler-Disk/) along with other useful scripts for Windows, macOS, and Linux.
 
 {: .note}
-> The Script will not work on 11th gen kindles and up due to Kindles ussing MTP to connect to comptuers.
-> Please manually fill your kindle by downloading the [zip file](https://github.com/bastianmarin/Kindle-Filler-Disk/tree/main/MTP/) below that matches your Kindle's storage. Extract it, then move the files onto the root of your kindle. Leave only 50-200MB of free.
-> If you need help, follow below but ignore Steps 3-5.
+> The script will not work on 11th gen Kindles and newer because these devices use MTP to connect to computers
+>
+> If this is your situation, you have two options:
+> 1. Delete any stray files ending in <code>.bin</code>, or have a similar name to <code>update.bin.tmp.partial</code> manually at every step of the Jailbreak guide
+> 2. Manually fill your Kindle. Download the [Filler files](https://github.com/bastianmarin/Kindle-Filler-Disk/tree/main/MTP/) that match your Kindle's storage from the link below. Extract the files, then move them to the root of your Kindle (you can also save them on a separate folder). After doing so, make sure to leave only 50–200 MB of free space
 
 
 <div id="guide">
@@ -43,7 +45,7 @@ You can use a simple script to fill your Kindle's storage with dummy files, leav
             <h2>1. Put Your Kindle in Airplane Mode</h2>
             <div class="stepContent">
                 <p>Turn on Airplane mode on your Kindle</p>
-                <img src="./Winterbreak/airplane_mode.png" />
+                <img src="./WinterBreak/airplane_mode.png" />
             </div>
         </div>
         <div class="step">
@@ -129,6 +131,7 @@ You can use a simple script to fill your Kindle's storage with dummy files, leav
     </div>
 </div>
 <style>
+
 .version-block {
     background-color: #1e1e1e;
     border-radius: 8px;
@@ -145,7 +148,8 @@ You can use a simple script to fill your Kindle's storage with dummy files, leav
     color: #369d36;
 }
 </style>
-<script>new Guide("guide");</script>
+
+<script>new Guide("guide", "./getting-started", "Jailbreak");</script>
 
 ---
 


### PR DESCRIPTION
So much needed re-writes and link re-directs to the wiki:

Winterbreak.
- Moved the last two notice classes inside the first step box to force people to read that indeed, **Winterbreak does not work on 5.18.1** and that they still need to fill their Kindles before registering or attempt to jailbreak 
- Moved the "re-enable airplane mode" line to the following step for better clarity as some people noted it was wrong on the discord channel, still unsure if this makes it clearer, *I am open to change this*. **I just don't want to make people think they can keep airplane mode enabled until the block OTA article**, because it's also possible that people straight up skipped the filling storage guide
- Re-ordered the Troubleshooting solutions, made the "Factory Reset" solution the second one because it's somewhat excessive

Disable-OTA.
- Added this [suggestion](https://github.com/KindleModding/kindlemodding.github.io/pull/48)
- Removed the mention of the Re-enabling store on the final box step because it's already included on the "next guide" button

Prevent Auto Update.
- Finally fixed the missing image on the first box step
- Wrote code tags for the bin file mentions for better clarity
- Expanded the MTP note notice class to cover people who cannot fill it because of MTP, covering this [issue](https://github.com/KindleModding/kindlemodding.github.io/issues/45)
- Added a link to the Getting Started page to the final box step, I would link it to the Winterbreak guide, but I also don't want to re-wrote it when the next jailbreak arrives

Re-enabling the Store.
- Added a link to the KOReader guide to the final step

KOReader.
- Added a link to the Kindle FAQ to the final step
