### PR TITLE
AdBreak Fixes

### DIFF
--- a/jailbreaking/AdBreak/index.md
+++ b/jailbreaking/AdBreak/index.md
@@ -44,7 +44,7 @@ If you face any issues, please check the [troubleshooting](#troubleshooting) sec
                     If your Kindle is <b>is not yet registered</b>, make sure to follow <a href="../prevent-auto-update.html">these steps to prevent your Kindle from automatically updating</a> before registering your device with Amazon. This will help you avoid an automatic firmware update during the registration process.
                 </p>
                 <p class="warning">
-                    Please use WinterBreak on firmware <code>5.18.0.2</code> and below.
+                    Please use WinterBreak on firmware <code>5.18.0.2</code> and below.<br/><br/><b>If you are on <code>5.18.5.0.1</code> download AdBreak from the <a href="#regarding-518501">troubleshooting</a> section!</b>
                 </p>
             </div>
         </div>
@@ -107,6 +107,9 @@ If you face any issues, please check the [troubleshooting](#troubleshooting) sec
             <h2>Jailbreak!</h2>
             <div class="stepContent">
                 <p>Unplug, click on an ad and go through the popups, once you click Close on "Bang!", the jailbreak script should run.</p>
+                <p class="note">
+                    You can safely ignore any "application error" popups, they are irrelevant.
+                </p>
                 <img src="./demo.png" />
             </div>
         </div>
@@ -146,6 +149,10 @@ If you face any issues, please check the [troubleshooting](#troubleshooting) sec
 - No, this is not "UJ"/"Unnamed Jailbreak". That is separate.
 - On mass storage kindles, **if you cannot see the `system` folder**, you will have to navigate to the path manually, or follow [this](https://kb.blackbaud.com/knowledgebase/Article/41890) guide to see protected system folders. 
 - "Is there a way to make my device ad supported?" (see below)
+
+### Regarding `5.18.5.0.1`
+
+This is a troublesome version. Try using [this](https://files.catbox.moe/j0mipf.zip) build of adbreak instead. If it fails, wait for an official update. This is a patched build I quickly made adding offsets for said firmware version.
 
 ### Enabling Ads
 (needed for jailbreak, safe to remove later)

--- a/jailbreaking/post-jailbreak/re-enabling-the-store/index.md
+++ b/jailbreaking/post-jailbreak/re-enabling-the-store/index.md
@@ -9,7 +9,7 @@ nav_order: 4
 # Re-enabling the Store
 
 {: .warning }
-Ensure you've [disabled OTA Updates](../disable-ota) before re-enabling the store.
+Ensure you've [disabled OTA Updates](../disable-ota) before re-enabling the store.<br/><br/>This is <b>WinterBreak-Only</b>, and it does not apply to AdBreak.
 
 <div id="guide">
     <div class="buttons">

--- a/jailbreaking/post-jailbreak/setting-up-a-hotfix/index.md
+++ b/jailbreaking/post-jailbreak/setting-up-a-hotfix/index.md
@@ -23,6 +23,12 @@ If you installed OTARenamer, make sure to uninstall it beforehand or the hotfix 
             <h2>Download The Hotfix</h2>
             <div class="stepContent">
                 <a href="https://github.com/KindleModding/Hotfix/releases/latest/download/Update_hotfix_universal.bin" class="btn btn-purple">Download</a>
+                <br/>
+                <a href="https://github.com/KindleModding/Hotfix/releases/download/v2.2.1/Update_hotfix_universal.bin" class="btn btn-purple">Download (Compatibility)</a>
+
+                <p class="warning">
+                    If scriptlets don't work, please redo these steps using the <b>compatibility hotfix!</b>
+                </p>
             </div>
         </div>
         <div class="step">


### PR DESCRIPTION
Changelog:

- Mentioned 5.18.5.0.1 complications and added a fixed alternative build I made which adds a couple offsets
- Mentioned you can ignore "application error" popups
- Mentioned re-enabling store is WinterBreak only
- Added "compatibility hotfix" linking to hotfix 2.2.1 before sh_it in c changes