### PR TITLE
Add warning to the OTA page about SpringBreak

### DIFF
--- a/content/jailbreaking/post-jailbreak/disable-ota.md
+++ b/content/jailbreaking/post-jailbreak/disable-ota.md
@@ -9,7 +9,7 @@ weight: 3
 
 Kindles automatically update when connected to Wi-Fi, which despite a `hotfix`, can often cause instabilities on jailbroken systems or outright remove the jailbreak.
 
-<p class="caution"><strong>This step is not necessary if you used [SpringBreak](../springbreak/).</strong></p>
+<p class="caution"><strong>This step is not necessary if you used <a href="../springbreak/">SpringBreak</a>.</strong></p>
 
 <div id="guide">
     <div class="buttons">

--- a/content/jailbreaking/post-jailbreak/disable-ota.md
+++ b/content/jailbreaking/post-jailbreak/disable-ota.md
@@ -9,6 +9,8 @@ weight: 3
 
 Kindles automatically update when connected to Wi-Fi, which despite a `hotfix`, can often cause instabilities on jailbroken systems or outright remove the jailbreak.
 
+<p class="caution"><strong>This step is not necessary if you used [SpringBreak](../springbreak/).</strong></p>
+
 <div id="guide">
     <div class="buttons">
         <button id="prev">Previous Step</button>

--- a/content/jailbreaking/post-jailbreak/disable-ota.md
+++ b/content/jailbreaking/post-jailbreak/disable-ota.md
@@ -9,7 +9,7 @@ weight: 3
 
 Kindles automatically update when connected to Wi-Fi, which despite a `hotfix`, can often cause instabilities on jailbroken systems or outright remove the jailbreak.
 
-<p class="caution"><strong>This step is not necessary if you used <a href="../springbreak/">SpringBreak</a>.</strong></p>
+<p class="caution"><strong>This step is not necessary if you used <a href="../SpringBreak/">SpringBreak</a>.</strong></p>
 
 <div id="guide">
     <div class="buttons">


### PR DESCRIPTION
You can't really reorganize the pages to fix this, so I just added a warning.

(I don't have time to test this, but it's a one line change, what's the worst that could happen?)