### PR TITLE
Fix broken links, remove dead links, and switch to relative paths

### DIFF
--- a/content/404.html
+++ b/content/404.html
@@ -25,5 +25,9 @@ navbar_exclude: true
   <h1>HTTP 404</h1>
   <p>Page Not Found!</p>
 
-  <a href="/" class="button">Go Home</a>  
+  <a id="404-base-url" class="button">Go Home</a>
 </div>
+
+<script>
+  document.getElementById("404-base-url").href = baseUrl;
+</script>

--- a/content/_index.md
+++ b/content/_index.md
@@ -97,22 +97,19 @@ params:
             <h1 style="color: var(--text-colour) !important;">Kindle Modding Wiki</h1>
             <p>Welcome to the Kindle Modding Wiki!</p>
             <p>Your one-stop shop for all things related to hacking Kindles.</p>
-            <a class="button" href="/jailbreaking">Get Started</a>
+            <a class="button" href="./jailbreaking">Get Started</a>
         </div>
     </div>
-
     <div class="landing-section buttons">
-        <a class="card" href="/kindle-dev/">
+        <a class="card" href="./kindle-dev">
             <h2 style="color: var(--text-colour) !important;">Developer Documentation</h2>
             <p>Documentation for homebrew developers</p>
         </a>
-
     <div class="landing-section buttons">
-        <a class="card" href="jailbreaking/jailbreak-faq.html">
+        <a class="card" href="./jailbreaking/jailbreak-faq.html">
             <h2 style="color: var(--text-colour) !important;">Jailbreak F.A.Q</h2>
             <p>Frequently Asked Questions</p>
         </a>
-
         <a class="card" href="http://discord.kindlemodding.org/">
             <h2 style="color: var(--text-colour) !important;">Discord</h2>
             <p>Join our Discord</p>

--- a/content/firmware-and-flashing/downgrading/__index.md
+++ b/content/firmware-and-flashing/downgrading/__index.md
@@ -62,7 +62,7 @@ Some devices may let you skip the initial device set-up by simply restarting the
 If you notice a <strong>significantly</strong> slower performance after the downgrade, it is recommended to perform a factory reset. Don't forget to backup your files and setting up the hotfix first
 </p>
 
-<a class="button" href="../../jailbreaking/post-jailbreak/setting-up-a-hotfix/">Setting Up A Hotfix</a>
+<a class="button" href="../../jailbreaking/Legacy/post-jailbreak/setting-up-a-hotfix/">Setting Up A Hotfix</a>
 
 ## Credits
 - Written by Bundlerocks, adapted from [Neon](https://kindlemodding.gitbook.io/kindlemodding/miscellaneous/downgrading-your-kindle-firmware)

--- a/content/jailbreak-wizard.html
+++ b/content/jailbreak-wizard.html
@@ -71,13 +71,13 @@ summary: Determine the appropriate jailbreak for your combination of circumstanc
         <h1>Jailbreaking Wizard</h1>
 
         <p>Let's get started with finding the most appropriate jailbreak for you!<br>Please enter the first 8 digits of your serial below:</p>
-       
+
         <div class="note">
             Your serial number can be found in<br/><code>Three Dots > Settings > Device options > Device info</code>.
         </div>
 
         <div class="caution">
-            <b>Before you begin ANYTHING, read <a href="/jailbreaking">this page</a> top to bottom.<br>Otherwise, don't expect any support.</b>
+            <b>Before you begin ANYTHING, read <a href="./jailbreaking">this page</a> top to bottom.<br>Otherwise, don't expect any support.</b>
         </div>
 
         <input type="text" id="serial" placeholder="G093 KM..." maxlength="8" oninput="searchForSerial();" autocomplete="off">
@@ -158,7 +158,7 @@ summary: Determine the appropriate jailbreak for your combination of circumstanc
         </div>
 
         <div class="warning">
-            Prior to jailbreaking/when waiting for a jailbreak, please <a href="/jailbreaking/prevent-auto-update/">fill up your Kindle</a> to prevent updates.<br>Otherwise, you may update to a firmware where the jailbreak/an upcoming jailbreak is patched!
+            Prior to jailbreaking/when waiting for a jailbreak, please <a href="./jailbreaking/prevent-auto-update/">fill up your Kindle</a> to prevent updates.<br>Otherwise, you may update to a firmware where the jailbreak/an upcoming jailbreak is patched!
         </div>
 
         <div class="buttons">

--- a/content/jailbreaking/AdBreak/__index.md
+++ b/content/jailbreaking/AdBreak/__index.md
@@ -23,8 +23,8 @@ It is based on [CVE-2012-3748](https://scarybeastsecurity.blogspot.com/2017/05/o
 
 - A PC, Cable, Kindle.
 - Unzipping Software (E.g., <a href="https://7-zip.org/">7-Zip</a>)
-- A registered, ad-enabled, supported model and firmware, as you have been led here by the <b><a href="/jailbreak-wizard.html">Jailbreaking Wizard</a></b>.
-- You have read <a href="/jailbreaking">this overview</a> and <a href="/jailbreaking/prevent-auto-update/">filled the device</a>, if applicable
+- A registered, ad-enabled, supported model and firmware, as you have been led here by the <b><a href="../../jailbreak-wizard.html">Jailbreaking Wizard</a></b>.
+- You have read <a href="../">this overview</a> and <a href="../prevent-auto-update/">filled the device</a>, if applicable
 - A Wi-Fi connection.
 
 > [!INFO]
@@ -45,7 +45,7 @@ It is based on [CVE-2012-3748](https://scarybeastsecurity.blogspot.com/2017/05/o
                 <div class="caution">
                     <b>Warning!</b><br>
                     Jailbreaking often involves connecting to the Internet.
-                    Before beginning <b>any</b> jailbreaking process, please remember to <a href="/jailbreaking/prevent-auto-update/">fill up your Kindle </a> as to avoid ruining the jailbreak mid-process. Additionally, please ensure <b>you have read <a href="/jailbreaking">this</a></b> before you start.
+                    Before beginning <b>any</b> jailbreaking process, please remember to <a href="../prevent-auto-update/">fill up your Kindle </a> as to avoid ruining the jailbreak mid-process. Additionally, please ensure <b>you have read <a href="../">this</a></b> before you start.
                 </div>
                 <p>If you have done the above, please commence to the next step.</p>
             </div>

--- a/content/jailbreaking/Legacy/K2DXDXGK3-Jailbreak/__index.md
+++ b/content/jailbreaking/Legacy/K2DXDXGK3-Jailbreak/__index.md
@@ -11,7 +11,7 @@ summary: A jailbreak for the now-discontinued K2, DX, DXG and K3 Kindles
 The NiLuJe K2/DX/DXG/K3 Jailbreak is a legacy jailbreak created by [NiLuJe](https://www.mobileread.com/forums/member.php?u=69624)
 
 ## Prerequisites
-- Please check that your Kindle is [compatible](../../jailbreak-wizard) with the K2 Jailbreak
+- Please check that your Kindle is [compatible](../../../jailbreak-wizard.html) with the K2 Jailbreak
 - You will also need a PC
 
 ## Installation Guide
@@ -80,7 +80,7 @@ The NiLuJe K2/DX/DXG/K3 Jailbreak is a legacy jailbreak created by [NiLuJe](http
         <button id="next">Next Step</button>
     </div>
 </div>
-<script>new Guide("guide", "/jailbreaking/Legacy/post-jailbreak/installing-kual-mrpi/", "Installing KUAL & MRPI");</script>
+<script>new Guide("guide", "../post-jailbreak/installing-kual-mrpi/", "Installing KUAL & MRPI");</script>
 
 <script>
 /**
@@ -348,7 +348,7 @@ function generateTable()
     table.replaceChildren(...newChildren);
 }
 
-fetch("/models.json").then(response => response.json()).then((data) => {
+fetch(`${baseUrl}models.json`).then(response => response.json()).then((data) => {
     window.kindleModels = data;
     generateTable();
 });

--- a/content/jailbreaking/Legacy/K4-Jailbreak/__index.md
+++ b/content/jailbreaking/Legacy/K4-Jailbreak/__index.md
@@ -11,7 +11,7 @@ summary: A jailbreak for the now-discontinued K4 Kindle
 The NiLuJe K4 Jailbreak is a legacy jailbreak created by [NiLuJe](https://www.mobileread.com/forums/member.php?u=69624)
 
 ## Prerequisites
-- Please check that your Kindle is [compatible](../../jailbreak-wizard) with the K2 Jailbreak
+- Please check that your Kindle is [compatible](../../../jailbreak-wizard.html) with the K2 Jailbreak
 - You will also need a PC
 
 ## Installation Guide
@@ -79,7 +79,7 @@ The NiLuJe K4 Jailbreak is a legacy jailbreak created by [NiLuJe](https://www.mo
         <button id="next">Next Step</button>
     </div>
 </div>
-<script>new Guide("guide", "/jailbreaking/Legacy/post-jailbreak/installing-kual-mrpi/", "Installing KUAL & MRPI");</script>
+<script>new Guide("guide", "../post-jailbreak/installing-kual-mrpi/", "Installing KUAL & MRPI");</script>
 
 ## Credits
 - Created by [NiLuJe](https://www.mobileread.com/forums/member.php?u=69624)

--- a/content/jailbreaking/Legacy/K5-Jailbreak/__index.md
+++ b/content/jailbreaking/Legacy/K5-Jailbreak/__index.md
@@ -11,7 +11,7 @@ summary: A jailbreak for the now-discontinued K5 Kindle
 The NiLuJe K5 Jailbreak is a legacy jailbreak created by [NiLuJe](https://www.mobileread.com/forums/member.php?u=69624)
 
 ## Prerequisites
-- Please check that your Kindle is [compatible](../../jailbreak-wizard) with the K2 Jailbreak
+- Please check that your Kindle is [compatible](../../../jailbreak-wizard.html) with the K2 Jailbreak
 - You will also need a PC
 
 ## Installation Guide
@@ -60,7 +60,7 @@ The NiLuJe K5 Jailbreak is a legacy jailbreak created by [NiLuJe](https://www.mo
         <button id="next">Next Step</button>
     </div>
 </div>
-<script>new Guide("guide", "/jailbreaking/Legacy/post-jailbreak/setting-up-a-hotfix/", "Setting up a hotfix");</script>
+<script>new Guide("guide", "../post-jailbreak/setting-up-a-hotfix/", "Setting up a hotfix");</script>
 
 ## Credits
 - Created by [NiLuJe](https://www.mobileread.com/forums/member.php?u=69624)

--- a/content/jailbreaking/Legacy/KindleBreak/__index.md
+++ b/content/jailbreaking/Legacy/KindleBreak/__index.md
@@ -10,7 +10,7 @@ slug: index
 [KindleBreak](https://www.mobileread.com/forums/showthread.php?t=338268) is jailbreak utilising the [`KindleDrip`](https://medium.com/realmodelabs/kindledrip-from-your-kindles-email-address-to-using-your-credit-card-bb93dbfb2a08) webkit exploit.
 
 ## Prerequisites
-- Please check that your Kindle is [compatible](../../jailbreak-wizard) with KindleBreak
+- Please check that your Kindle is [compatible](../../../jailbreak-wizard.html) with KindleBreak
 - You will also need a PC
 
 > [!WARNING]
@@ -31,7 +31,7 @@ slug: index
 
 You are now ready to check the `Post Jailbreak` section for what to do now.
 
-<a class="button" href="./post-jailbreak/">Post Jailbreak</a>
+<a class="button" href="../post-jailbreak/">Post Jailbreak</a>
 
 ## Credits
 - Original guide written by [Neon](https://www.mobileread.com/forums/member.php?u=329187)

--- a/content/jailbreaking/Legacy/LanguageBreak.md
+++ b/content/jailbreaking/Legacy/LanguageBreak.md
@@ -11,7 +11,7 @@ weight: 1
 [LanguageBreak](https://www.mobileread.com/forums/showthread.php?t=356872) is jailbreak utilising a novel [`langpicker-nativebridge`](https://www.mobileread.com/forums/showthread.php?t=356766) exploit.
 
 ## Prerequisites
-- Please check that your Kindle is [compatible](../../jailbreak-wizard) with LanguageBreak
+- Please check that your Kindle is [compatible](../../jailbreak-wizard.html) with LanguageBreak
 - You will also need a PC
 
 > [!WARNING]

--- a/content/jailbreaking/Legacy/WatchThis/__index.md
+++ b/content/jailbreaking/Legacy/WatchThis/__index.md
@@ -10,7 +10,7 @@ slug: index
 [WatchThis](https://www.mobileread.com/forums/showthread.php?t=346037) is a jailbreak utilising a `demo payload` exploit.
 
 ## Prerequisites
-- Please check that your Kindle is [compatible](../../jailbreak-wizard) with WatchThis
+- Please check that your Kindle is [compatible](../../../jailbreak-wizard.html) with WatchThis
 - You will also need a PC
 
 > [!WARNING]

--- a/content/jailbreaking/Legacy/post-jailbreak/_index.md
+++ b/content/jailbreaking/Legacy/post-jailbreak/_index.md
@@ -12,6 +12,6 @@ Once you have jailbroken your Kindle, there are still some extremely important s
 > [!WARNING]
 > Turn on Airplane mode now so your Kindle doesn't automatically update to latest firmware before applying OTArenamer!
 
-<a class="button" href="/jailbreaking/Legacy/post-jailbreak/setting-up-a-hotfix">Setup a Hotfix</a>
+<a class="button" href="./setting-up-a-hotfix">Setup a Hotfix</a>
 
 *Note, that this now only applies to Legacy jailbreaks, and so this section has been moved for preservation purposes.

--- a/content/jailbreaking/Legacy/post-jailbreak/disable-ota.md
+++ b/content/jailbreaking/Legacy/post-jailbreak/disable-ota.md
@@ -63,7 +63,7 @@ Kindles automatically update when connected to Wi-Fi, which despite a `hotfix`, 
             <div class="stepContent">
                 <div class="version-block">
                     <p class="version-label">Firmware <=5.10.x:</p>
-                    <p>Navigate to the <a href="https://kindlemodding.org/jailbreaking/jailbreak-faq.html#what-is-the-root-directory">root directory</a> of your Kindle</p>
+                    <p>Navigate to the <a href="../../jailbreak-faq.html#what-is-the-root-directory">root directory</a> of your Kindle</p>
                     <p>Create a folder called <code>update.bin.tmp.partial</code></p>
                 </div>
                 <div class="version-block">

--- a/content/jailbreaking/Legacy/post-jailbreak/installing-kual-mrpi/__index.md
+++ b/content/jailbreaking/Legacy/post-jailbreak/installing-kual-mrpi/__index.md
@@ -35,7 +35,7 @@ You will need to install KUAL (Kindle Unified Application Launcher) and MRPI (Mo
                     </tr>
                     <tr>
                         <td>K4 and older</td>
-                        <td>Download, place in documents folder and move onto <a href="../koreader.html">Installing KOReader</a></td>
+                        <td>Download, place in documents folder and move onto <a href="../../../whats-next/getting-koreader/">Installing KOReader</a></td>
                         <td><a href="./KUAL-KDK-1.0.azw2">KUAL-KDK-1.0.azw2</a></td>
                     </tr>
                 </tbody>

--- a/content/jailbreaking/Nosebleed/__index.md
+++ b/content/jailbreaking/Nosebleed/__index.md
@@ -20,8 +20,8 @@ Nosebleed is a jailbreak released on 02/03/2026 by hhhhhhhhh.
 
 - A PC, Cable, Kindle.
 - Unzipping Software (E.g., <a href="https://7-zip.org/">7-Zip</a>)
-- A supported model and firmware, as you have been led here by the <b><a href="/jailbreak-wizard.html">Jailbreaking Wizard</a></b>.
-- You have read <a href="/jailbreaking">this overview</a> and <a href="/jailbreaking/prevent-auto-update/">filled the device</a>, if applicable
+- A supported model and firmware, as you have been led here by the <b><a href="../../jailbreak-wizard.html">Jailbreaking Wizard</a></b>.
+- You have read <a href="../">this overview</a> and <a href="../prevent-auto-update/">filled the device</a>, if applicable
 - A Wi-Fi connection.
 
 <blockquote class="note">
@@ -43,7 +43,7 @@ Nosebleed is a jailbreak released on 02/03/2026 by hhhhhhhhh.
                 <div class="caution">
                     <b>Warning!</b><br>
                     Jailbreaking often involves connecting to the Internet.
-                    Before beginning <b>any</b> jailbreaking process, please remember to <a href="/jailbreaking/prevent-auto-update/">fill up your Kindle </a> as to avoid ruining the jailbreak mid-process. Additionally, please ensure <b>you have read <a href="/jailbreaking">this</a></b> before you start.
+                    Before beginning <b>any</b> jailbreaking process, please remember to <a href="../prevent-auto-update/">fill up your Kindle </a> as to avoid ruining the jailbreak mid-process. Additionally, please ensure <b>you have read <a href="../">this</a></b> before you start.
                 </div>
                 <p>If you have done the above, please commence to the next step.</p>
             </div>

--- a/content/jailbreaking/Sanctuary/__index.md
+++ b/content/jailbreaking/Sanctuary/__index.md
@@ -17,8 +17,8 @@ Sanctuary is a jailbreak released on 30/06/2026 by [Ava](https://ko-fi.com/yubai
 ## Prerequisites
 
 - A PC, Kindle.
-- A supported model and firmware, as you have been led here by the <b><a href="/jailbreak-wizard.html">Jailbreaking Wizard</a></b>.
-- You have read <a href="/jailbreaking">this overview</a> and <a href="/jailbreaking/prevent-auto-update/">filled the device</a>, if applicable
+- A supported model and firmware, as you have been led here by the <b><a href="../../jailbreak-wizard.html">Jailbreaking Wizard</a></b>.
+- You have read <a href="../">this overview</a> and <a href="../prevent-auto-update/">filled the device</a>, if applicable
 - A Wi-Fi connection.
 
 > [!INFO]
@@ -39,7 +39,7 @@ Sanctuary is a jailbreak released on 30/06/2026 by [Ava](https://ko-fi.com/yubai
                 <div class="caution">
                     <b>Warning!</b><br>
                     Jailbreaking often involves connecting to the Internet.
-                    Before beginning <b>any</b> jailbreaking process, please remember to <a href="/jailbreaking/prevent-auto-update/">fill up your Kindle </a> as to avoid ruining the jailbreak mid-process. Additionally, please ensure <b>you have read <a href="/jailbreaking">this</a></b> before you start.
+                    Before beginning <b>any</b> jailbreaking process, please remember to <a href="../prevent-auto-update/">fill up your Kindle </a> as to avoid ruining the jailbreak mid-process. Additionally, please ensure <b>you have read <a href="../">this</a></b> before you start.
                 </div>
                 <p>If you have done the above, please commence to the next step.</p>
             </div>
@@ -61,7 +61,7 @@ Sanctuary is a jailbreak released on 30/06/2026 by [Ava](https://ko-fi.com/yubai
                 <p>Compare your scroll bar to the images below.</p>
                 <p>If your scroll bar appears to be the one on the left, you can proceed to the next step.</p>
                 <p class="warning">
-                    If your scroll bar is the one on the right, you will have to <a href="../../firmware-and-flashing/downloading-updates">manually update your firmware to the latest jailbreakable version.</a>
+                    If your scroll bar is the one on the right, you will have to <a href="../../firmware-and-flashing/downloading-updates.html">manually update your firmware to the latest jailbreakable version.</a>
                 </p>
                 <img src="./scroll.png">
             </div>

--- a/content/jailbreaking/SpringBreak/__index.md
+++ b/content/jailbreaking/SpringBreak/__index.md
@@ -23,8 +23,8 @@ You can read the writeup [here](https://penguins184.xyz/blog/springbreak-jailbre
 
 - A PC, Cable, Kindle.
 - Unzipping Software (E.g., <a href="https://7-zip.org/">7-Zip</a>)
-- A registered, supported model and firmware, as you have been led here by the <b><a href="/jailbreak-wizard.html">Jailbreaking Wizard</a></b>.
-- You have read <a href="/jailbreaking">this overview</a>
+- A registered, supported model and firmware, as you have been led here by the <b><a href="../../jailbreak-wizard.html">Jailbreaking Wizard</a></b>.
+- You have read <a href="../">this overview</a>
 - A Wi-Fi connection.
 
 > [!INFO]
@@ -44,7 +44,7 @@ You can read the writeup [here](https://penguins184.xyz/blog/springbreak-jailbre
             <div class="stepContent">
                 <a href="https://github.com/KindleModding/SpringBreak/releases/latest/download/springbreak.zip" class="button">Download</a>
                 <p class="note">
-                    On the contrary to other jailbreaks, <b>Filler files may make this process FAIL.</b> This process creates thousands of nested folders to work on your Kindle, if there is not enough space it won't work! Preferably, leave more space and don't use Wi-Fi. Also, do it fast. <b>Nethertheless, read <a href="/jailbreaking">this</a> before you start.</b>
+                    On the contrary to other jailbreaks, <b>Filler files may make this process FAIL.</b> This process creates thousands of nested folders to work on your Kindle, if there is not enough space it won't work! Preferably, leave more space and don't use Wi-Fi. Also, do it fast. <b>Nethertheless, read <a href="../">this</a> before you start.</b>
                 </p>
                 <p class="tip">
                     On MacOS, you do not need to do this. The command you will run later in this guide does it automatically!

--- a/content/jailbreaking/Vera/__index.md
+++ b/content/jailbreaking/Vera/__index.md
@@ -21,8 +21,8 @@ It will be ported to `KS3(NFL)` and `KSC` firmwares <=5.19.6 in the future.
 ## Prerequisites
 
 - A Kindle
-- A supported model and firmware, as you have been led here by the <b><a href="/jailbreak-wizard.html">Jailbreaking Wizard</a></b>.
-- You have read <a href="/jailbreaking">this overview</a> and <a href="/jailbreaking/prevent-auto-update/">filled the device</a>, if applicable
+- A supported model and firmware, as you have been led here by the <b><a href="../../jailbreak-wizard.html">Jailbreaking Wizard</a></b>.
+- You have read <a href="../">this overview</a> and <a href="../prevent-auto-update/">filled the device</a>, if applicable
 - A Wi-Fi connection.
 
 > [!INFO]
@@ -43,7 +43,7 @@ It will be ported to `KS3(NFL)` and `KSC` firmwares <=5.19.6 in the future.
                 <div class="caution">
                     <b>Warning!</b><br>
                     Jailbreaking often involves connecting to the Internet.
-                    Before beginning <b>any</b> jailbreaking process, please remember to <a href="/jailbreaking/prevent-auto-update/">fill up your Kindle </a> as to avoid ruining the jailbreak mid-process. Additionally, please ensure <b>you have read <a href="/jailbreaking">this</a></b> before you start.
+                    Before beginning <b>any</b> jailbreaking process, please remember to <a href="../prevent-auto-update/">fill up your Kindle </a> as to avoid ruining the jailbreak mid-process. Additionally, please ensure <b>you have read <a href="../">this</a></b> before you start.
                 </div>
                 <p>If you have done the above, please commence to the next step.</p>
             </div>

--- a/content/jailbreaking/WinterBreak/__index.md
+++ b/content/jailbreaking/WinterBreak/__index.md
@@ -30,8 +30,8 @@ WinterBreak is a jailbreak which was released on New Year's Day 2025 by [Hackerd
 
 - A PC, Cable, Kindle.
 - Unzipping Software (E.g., <a href="https://7-zip.org/">7-Zip</a>)
-- A registered, supported model and firmware, as you have been led here by the <b><a href="/jailbreak-wizard.html">Jailbreaking Wizard</a></b>.
-- You have read <a href="/jailbreaking">this overview</a> and <a href="/jailbreaking/prevent-auto-update/">filled the device</a>, if applicable
+- A registered, supported model and firmware, as you have been led here by the <b><a href="../../jailbreak-wizard.html">Jailbreaking Wizard</a></b>.
+- You have read <a href="../">this overview</a> and <a href="../prevent-auto-update/">filled the device</a>, if applicable
 - A Wi-Fi connection.
 
 > [!INFO]
@@ -52,7 +52,7 @@ WinterBreak is a jailbreak which was released on New Year's Day 2025 by [Hackerd
                 <div class="caution">
                     <b>Warning!</b><br>
                     Jailbreaking often involves connecting to the Internet.
-                    Before beginning <b>any</b> jailbreaking process, please remember to <a href="/jailbreaking/prevent-auto-update/">fill up your Kindle </a> as to avoid ruining the jailbreak mid-process. Additionally, please ensure <b>you have read <a href="/jailbreaking">this</a></b> before you start.
+                    Before beginning <b>any</b> jailbreaking process, please remember to <a href="../prevent-auto-update/">fill up your Kindle </a> as to avoid ruining the jailbreak mid-process. Additionally, please ensure <b>you have read <a href="../">this</a></b> before you start.
                 </div>
                 <p>If you have done the above, please commence to the next step.</p>
             </div>

--- a/content/jailbreaking/WinterBreak2/__index.md
+++ b/content/jailbreaking/WinterBreak2/__index.md
@@ -19,8 +19,8 @@ WinterBreak2 is a browser-based jailbreak created by [Scam.Net](https://github.c
 
 - A PC, Cable, Kindle.
 - Unzipping Software (E.g., <a href="https://7-zip.org/">7-Zip</a>)
-- A supported model and firmware, as you have been led here by the <b><a href="/jailbreak-wizard.html">Jailbreaking Wizard</a></b>.
-- You have read <a href="/jailbreaking">this overview</a> and <a href="/jailbreaking/prevent-auto-update/">filled the device</a>, if applicable
+- A supported model and firmware, as you have been led here by the <b><a href="../../jailbreak-wizard.html">Jailbreaking Wizard</a></b>.
+- You have read <a href="../">this overview</a> and <a href="../prevent-auto-update/">filled the device</a>, if applicable
 - A Wi-Fi connection.
 
 > [!INFO]
@@ -41,7 +41,7 @@ WinterBreak2 is a browser-based jailbreak created by [Scam.Net](https://github.c
                 <div class="caution">
                     <b>Warning!</b><br>
                     Jailbreaking often involves connecting to the Internet.
-                    Before beginning <b>any</b> jailbreaking process, please remember to <a href="/jailbreaking/prevent-auto-update/">fill up your Kindle </a> as to avoid ruining the jailbreak mid-process. Additionally, please ensure <b>you have read <a href="/jailbreaking">this</a></b> before you start.
+                    Before beginning <b>any</b> jailbreaking process, please remember to <a href="../prevent-auto-update/">fill up your Kindle </a> as to avoid ruining the jailbreak mid-process. Additionally, please ensure <b>you have read <a href="../">this</a></b> before you start.
                 </div>
                 <p>If you have done the above, please commence to the next step.</p>
             </div>

--- a/content/jailbreaking/_index.md
+++ b/content/jailbreaking/_index.md
@@ -32,7 +32,7 @@ Here are some important things to note before you begin. This information applie
 
 <p class="warning" style="filter: hue-rotate(150deg);">
     <b>Can I remove the Jailbreak?</b><br>
-    Yes. If you wish to remove the jailbreak, you must run <a href="./ota.sh" download>this</a> scriptlet (<a href="whats-next/installing-homebrew.html">'scriptlet' term definition</a>), factory reset the device, then push an update (whether it be to the same firmware, you can download an update file from <a href="https://ftvdb.com/kindle/firmware/">FTVDB</a>, place it in the Kindle's root and hit the update button). After this, <b>every trace</b> of the Jailbreak will be removed.
+    Yes. If you wish to remove the jailbreak, you must run <a href="./ota.sh" download>this</a> scriptlet (<a href="./whats-next/installing-homebrew.html">'scriptlet' term definition</a>), factory reset the device, then push an update (whether it be to the same firmware, you can download an update file from <a href="https://ftvdb.com/kindle/firmware/">FTVDB</a>, place it in the Kindle's root and hit the update button). After this, <b>every trace</b> of the Jailbreak will be removed.
 </p>
 
 <p class="caution">
@@ -44,7 +44,7 @@ Here are some important things to note before you begin. This information applie
 
 ---
 
-<h2>With that out of the way,</h2> You can begin the process <a href="/jailbreak-wizard.html">here</a>. When the wizard identifies which jailbreak you should use, it will also notify you to <b><a href=""></a></b> fill up the Kindle to temporarily prevent automatic updates, and I am reiterating this. Knowing all of this information, it is far more likely you will have a safer and more enjoyable jailbreaking experience! :)
+<h2>With that out of the way,</h2> You can begin the process <a href="../jailbreak-wizard.html">here</a>. When the wizard identifies which jailbreak you should use, it will also notify you to <b><a href=""></a></b> fill up the Kindle to temporarily prevent automatic updates, and I am reiterating this. Knowing all of this information, it is far more likely you will have a safer and more enjoyable jailbreaking experience! :)
 
 Also, for those who are curious (<b>or do not actually know what a jailbreak can lead to</b>), here is a list of some jailbreaking pro's-and-con's, just to get an idea of what's in store. 
 

--- a/content/jailbreaking/jailbreak-faq.md
+++ b/content/jailbreaking/jailbreak-faq.md
@@ -22,7 +22,7 @@ Most of these instructions are subjected to changes due to newer jailbreaks, pat
 
 You'll have to wait for a new jailbreak method (or patch) to be released. **This may take weeks or even months**. To protect your Kindle from automatic updates, **forget** all saved internet connections, enable Airplane mode, and wait.
 
-If you still want to use the internet on your Kindle while avoiding automatic updates, you might find [this guide helpful](https://kindlemodding.org/jailbreaking/prevent-auto-update).
+If you still want to use the internet on your Kindle while avoiding automatic updates, you might find [this guide helpful](./prevent-auto-update).
 
 #### Can I downgrade my Kindle so I can jailbreak it?
 
@@ -52,10 +52,6 @@ No reports of Amazon accounts being banned after jailbreaking have been reported
 
 ### Will this void the warranty on my Kindle device?
 Probably.
-
-### How do I get the Amazon store back again?
-
-[Read and follow this guide](https://kindlemodding.org/jailbreaking/post-jailbreak/re-enabling-the-store/).
 
 ### What does soft-float and hard-float firmware means?
 
@@ -126,7 +122,7 @@ KOReader currently does not support USBMS mode (USB transfer) and will only char
 
 Not necessarily.
 
-You can launch it with simple [scriptlets](https://kindlemodding.org/kindle-dev/scriptlets.html), specifically, Marek's launcher that is available [here](https://scriptlets.notmarek.com/).
+You can launch it with simple [scriptlets](../kindle-dev/scriptlets.html), specifically, Marek's launcher that is available [here](https://scriptlets.notmarek.com/).
 
 [KOR booklet launcher (made by yparitcher)](https://github.com/yparitcher/KUAL_Booklet/releases/) is also available to install. You can further customize both the KUAL booklet and the KOReader launcher with the [coversetter extension made by Stanner](https://www.mobileread.com/forums/showpost.php?p=4222466&postcount=15).
 
@@ -151,7 +147,7 @@ After updating/factory reset/downgrading, reinstall the hotfix from scratch. KUA
 
 ### How do I downgrade my Kindle?
 
-[Read and follow this guide](../firmware-and-flashing/downgrading/#downgrading-your-kindle).
+[Read and follow this guide](../firmware-and-flashing/downgrading/).
 
 ### Where can I download firmware update files?
 
@@ -161,7 +157,7 @@ Find your exact model, find the download link and re-type the numbers to get the
 
 ### How do I use Scriptlets (.sh)?
 
-As explained in the [Scriptlets section](https://kindlemodding.org/kindle-dev/scriptlets.html#siptlets), copy the scriptlet file into the documents folder (`/documents`). Once you're in the library view mode on Kindle, simply click on it.
+As explained in the [Scriptlets section](../kindle-dev/scriptlets.html), copy the scriptlet file into the documents folder (`/documents`). Once you're in the library view mode on Kindle, simply click on it.
 
 ### How can I check that the automatic updates have been disabled after using `renametobin`?
 
@@ -190,13 +186,13 @@ Type `;log` into the search bar, if a message pop ups, you're jailbroken.
 ### KUAL stopped working!/I can't no longer launch any of my extensions!
 Verify if your device is still jailbroken by typing `;log` into the search bar.
 
-- If it prompted any text, [reinstall the hotfix and KUAL](https://kindlemodding.org/jailbreaking/post-jailbreak/setting-up-a-hotfix/) from scratch.
-- If not [re-jailbreak](https://kindlemodding.org/jailbreak-wizard) your device.
+- If it prompted any text, [reinstall the hotfix and KUAL](./Legacy/post-jailbreak/setting-up-a-hotfix/) from scratch.
+- If not [re-jailbreak](../jailbreak-wizard.html) your device.
 - If everything else failed, factory reset your device and start the jailbreak from scratch. 
 
 ### I can't no longer update my Kindle after a factory reset/update!
 
-If you reset your Kindle in a jailbroken state with renametobin left enabled, your Kindle may be in a locked state. To fix this, read [this guide](https://kindlemodding.org/jailbreaking/recovering-from-a-reset.html).
+If you reset your Kindle in a jailbroken state with renametobin left enabled, your Kindle may be in a locked state. To fix this, read [this guide](./recovering-from-a-reset.html).
 
 ### I get a message saying "Failed to remount rootfs RO, waiting"!
 
@@ -220,11 +216,11 @@ This is also the case for the "Collecting Debug Info" message.
 
 You can do one of the following:
 
-- [Install KOReader](https://kindlemodding.org/jailbreaking/post-jailbreak/koreader.html)
-- [Downgrade your Kindle](https://kindlemodding.org/firmware-and-flashing/downgrading/)
+- [Install KOReader](./whats-next/getting-koreader/)
+- [Downgrade your Kindle](../firmware-and-flashing/downgrading/)
 - Download scriptlets:
     - [Marek's Scriplets](https://scriptlets.notmarek.com/)
-- [Develop more extensions](https://kindlemodding.org/kindle-dev/) 
+- [Develop more extensions](../kindle-dev/)
 - Browse [MobileRead](https://www.mobileread.com/forums/forumdisplay.php?f=150) or the Kindle Modding Community Discord Server for more scriplets and extensions.
 - Install Alpine Linux
 - [Support Winterbreak & the Wiki ❤️](https://ko-fi.com/hackerdude) 

--- a/content/jailbreaking/prevent-auto-update/__index.md
+++ b/content/jailbreaking/prevent-auto-update/__index.md
@@ -109,7 +109,7 @@ You can use a simple script to fill your Kindle's storage with dummy files, leav
             <div class="stepContent">
                 <p>With storage nearly full, you can now connect to Wi-Fi and register your Kindle to your Amazon account.</p> 
                 <p>The Kindle will not be able to fully download the update due to a lack of space.</p>
-                <p>You can either perform a <a href="/jailbreak-wizard.html">Jailbreak suitable for your device</a> or wait for the next jailbreak to be released.</p> 
+                <p>You can either perform a <a href="../../jailbreak-wizard.html">Jailbreak suitable for your device</a> or wait for the next jailbreak to be released.</p>
                 <p class="info">
                   Always make sure to delete any files ending with <code>.bin</code> or named <code>update.bin.tmp.partial</code>
                 </p>
@@ -123,7 +123,7 @@ You can use a simple script to fill your Kindle's storage with dummy files, leav
     </div>
 </div>
 
-<script>new Guide("guide", "/jailbreaking/", "Jailbreak");</script>
+<script>new Guide("guide", "../", "Jailbreak");</script>
 
 ---
 

--- a/content/jailbreaking/recovering-from-a-reset.md
+++ b/content/jailbreaking/recovering-from-a-reset.md
@@ -7,10 +7,10 @@ weight: 12
 
 # Recovering From a Reset
 
-Factory resetting a jailbroken Kindle means it has updates blocked and you will never be able to install official update files (<b>crucial</b> for removing all traces of a jailbreak on a Kindle). See the <a href="/jailbreaking/">jailbreaking lander</a> for more information.
+Factory resetting a jailbroken Kindle means it has updates blocked and you will never be able to install official update files (<b>crucial</b> for removing all traces of a jailbreak on a Kindle). See the <a href="../jailbreaking/">jailbreaking lander</a> for more information.
 
 In order to restore the Kindle's ability to update, please install <a href="./ota.sh" download>this</a> scriptlet.
 
 <div class="note">
-    Scriptlets, and how to install them, are explained <a href="/jailbreaking/whats-next/installing-homebrew.html">here</a>.
+    Scriptlets, and how to install them, are explained <a href="./whats-next/installing-homebrew.html">here</a>.
 </div>

--- a/content/jailbreaking/whats-next/getting-koreader/__index.md
+++ b/content/jailbreaking/whats-next/getting-koreader/__index.md
@@ -30,21 +30,21 @@ KOReader is a document viewer for E-Ink devices. Supported formats include EPUB,
             <h2>Update Sources</h2>
             <div class="stepContent">
                 <p>Run <code>;kpm update</code> in the searchbar on the homescreen (and press return/enter).</p><br><p>You will see some text at the top of the screen, before you're returned to the homepage.</p>
-                <img src="update.png">
+                <img src="./update.png">
             </div>
         </div>
         <div class="step">
             <h2>Install</h2>
             <div class="stepContent">
                 <p>Now, run <code>;kpm install koreader</code> in the searchbar.</p><br><p>Wait a few moments, you'll be returned to the homescreen and a new Scriptlet will have appeared (the icon may not instantly appear).</p>
-                <img src="booklet.png">
+                <img src="./booklet.png">
             </div>
         </div>
         <div class="step">
             <h2>Run!</h2>
             <div class="stepContent">
                 <p>Click on it, and KOReader will run!</p><br><p>Alternatively, you can also run <code>;kpm launch koreader</code> to use it.</p>
-                <img src="koreader.png">
+                <img src="./koreader.png">
             </div>
         </div>
         <div class="step">

--- a/content/jailbreaking/whats-next/installing-homebrew.md
+++ b/content/jailbreaking/whats-next/installing-homebrew.md
@@ -49,4 +49,4 @@ Please note, that software called <code>KUAL</code> was formerly used to launch 
 
 With that out of the way, KOReader installation will be covered to show KPM basics. After that, what you install is fully up to you (you don't even need KOReader! What am I, your mother?).
 
-<a href="./getting-koreader/__index.html"><button>Getting KOReader</button></a>
+<a href="./getting-koreader/"><button>Getting KOReader</button></a>

--- a/content/kindle-apps-and-services/com.lab126.scanner/_index.md
+++ b/content/kindle-apps-and-services/com.lab126.scanner/_index.md
@@ -6,7 +6,7 @@ title: com.lab126.scanner
 # com.lab126.scanner
 The scanner is a core component of the Kindle system. It watches the userstore filesystem at `/mnt/us/` and indexes books.
 
-[appreg.db](/kindle-hacking/appreg.html) is used to determine corresponding file associations.  
+[appreg.db](../../kindle-hacking/appreg.html) is used to determine corresponding file associations.  
 For more information on how books are indexed, please see the [extractors](./extractors.html) section
 
 ## LIPC Properties

--- a/content/kindle-dev/_index.md
+++ b/content/kindle-dev/_index.md
@@ -5,6 +5,6 @@ weight: 3
 ---
 
 # Kindle Development
-As mentioned in [Kindle OS](/kindle-os/), the Kindle runs Linux, this means that you can develop your own applications for it, which run natively on the Kindle.
+The Kindle runs Linux, this means that you can develop your own applications for it, which run natively on the Kindle.
 
 This section of the wiki is primarily aimed towards native development with C/C++ via the Meson Build System

--- a/content/kindle-dev/gtk-tutorial/kindle-considerations.md
+++ b/content/kindle-dev/gtk-tutorial/kindle-considerations.md
@@ -9,4 +9,4 @@ weight: 3
 There are some important things to consider when writing GUI-based applications on the Kindle
 
 ## Window Title
-See: Awesome Window Manager
+See: [Awesome Window Manager](../awesome-window-manager/)

--- a/content/kindle-dev/kpm/_index.md
+++ b/content/kindle-dev/kpm/_index.md
@@ -12,4 +12,4 @@ KPM is a package manager, it is a tool which indexes Kindle homebrew and allows 
 Each developer is expected to submit to the official [KindleModding KPM repository](https://github.com/KindleModding/repo/pulls) or host their own repository (repositories can be hosted statically on GitHub pages)
 
 ## How do I create a package?
-See [Creating a package](creating-a-package.html)
+See [Creating a package](./creating-a-package.html)

--- a/content/kindle-hacking/appreg.md
+++ b/content/kindle-hacking/appreg.md
@@ -19,7 +19,7 @@ It contains the following tables:
 
 ## associations
 The associations table is the most important table in the `appreg.db` file, linking specific *handlers* to specific types of *content* or *interfaces*.  
-It is most notably used by [scanner](../kindle-apps-and-services/com.lab126.scanner.html) to determine what *extractor* to use when indexing a file.  
+It is most notably used by [scanner](../kindle-apps-and-services/com.lab126.scanner/) to determine what *extractor* to use when indexing a file.  
 It is also used to determine what application to launch when opening a booklet.
 
 | handlerId | interface | contentId | defaultAssoc |

--- a/content/kindle-hacking/hotfix.md
+++ b/content/kindle-hacking/hotfix.md
@@ -51,7 +51,7 @@ Once this is done, it performs numerous steps:
 - The `dispatch.sh` [debug command](./debug-commands.html) is copied to `/usr/bin/logThis.sh`
 - `/var/local/kmc/KMCLog.sh` is given execute permissions
 - The `run_bridge.sh` file from old hotfixes is removed and replaced with `Run Hotfix.run_hotfix`
-- `appreg.db` is modified to install the hotfix booklet and `sh_integration` (see also: [appreg.db](./appreg.html) and [Scanner](../kindle-apps-and-services/com.lab126.scanner.html))
+- `appreg.db` is modified to install the hotfix booklet and `sh_integration` (see also: [appreg.db](./appreg.html) and [Scanner](../kindle-apps-and-services/com.lab126.scanner/))
 
 ## Running Hotfix
 Once the hotfix is installed, the Kindle is very nearly jailbroken, however, some final stages that cannot be performed in the OTA environment need to be done. As such, the `Run Hotfix` booklet is created to do this.  

--- a/content/wafs-and-mesquite/the-kindle-object/kindle-chrome.md
+++ b/content/wafs-and-mesquite/the-kindle-object/kindle-chrome.md
@@ -23,9 +23,6 @@ kindle.chrome.setTitleBar(centerText, leftText)
 ~~~
 Seemingly accepts 2 string arguments, purpose is unknown, possibly `deprecated` in modern Kindle firmware versions
 
-> [!WARNING]
-> `DO NOT` use this in `Mesquite` applications, that is what the [`SDK`](../../mesquito/development/the-mesquito-sdk.html) is for
-
 
 ## kindle.chrome.createHeader
 ~~~js

--- a/layouts/_partials/head_global.html
+++ b/layouts/_partials/head_global.html
@@ -31,9 +31,13 @@
 
 {{ partial "include-scss.html" "css/main" }}
 
-<script src="/assets/js/global.js"></script>
-<script src="/assets/js/fluent_guide.js"></script>
-<script src="/assets/js/search.js"></script>
+<script>
+  const baseUrl = "{{ .Site.BaseURL }}";
+</script>
+
+<script src="{{ .Site.BaseURL }}/assets/js/global.js"></script>
+<script src="{{ .Site.BaseURL }}/assets/js/fluent_guide.js"></script>
+<script src="{{ .Site.BaseURL }}/assets/js/search.js"></script>
 
 <!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -1,6 +1,6 @@
 <div class="navbar" role="navigation">
     <div>
-        <h1 style="color: var(--text-colour) !important;"><a href="/" style="text-decoration: none; color: unset !important; background: none !important; padding: 0 !important;">Kindle Modding Wiki</a></h1>
+        <h1 style="color: var(--text-colour) !important;"><a href="{{ .Site.BaseURL }}" style="text-decoration: none; color: unset !important; background: none !important; padding: 0 !important;">Kindle Modding Wiki</a></h1>
     </div>
 
     <div class="search-container">

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -34,7 +34,7 @@
   <body>
 
     <div class="pageWrapper">
-      {{ partial "navbar" }}
+      {{ partial "navbar" . }}
 
       <div class="pageContent">
         <div class="mainContent" role="main">

--- a/static/assets/js/global.js
+++ b/static/assets/js/global.js
@@ -1,7 +1,7 @@
 const registerServiceWorker = async () => {
     if ("serviceWorker" in navigator) {
         try {
-            const registration = await navigator.serviceWorker.register("/service_worker.js", {
+            const registration = await navigator.serviceWorker.register(`${baseUrl}service_worker.js`, {
                 scope: "/",
             });
             if (registration.installing) {

--- a/static/assets/js/search.js
+++ b/static/assets/js/search.js
@@ -6,7 +6,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   if (!searchInput || !searchResults) return;
 
-  fetch("/search_index.json")
+  fetch(`${baseUrl}search_index.json`)
     .then((response) => response.json())
     .then((data) => {
       searchIndex = data;
@@ -33,7 +33,7 @@ document.addEventListener("DOMContentLoaded", () => {
     displayResults();
   }
 
-  
+
   document.addEventListener("mousedown", (e) => {
     if (!searchInput.contains(e.target) && !searchResults.contains(e.target)) {
       searchResults.style.display = "none";

--- a/static/jailbreakFinder.js
+++ b/static/jailbreakFinder.js
@@ -3,7 +3,7 @@ const readLander = localStorage.getItem("readLander");
 if(!readLander) {
     showDialog(
         "Halt!",
-        `We have detected <b>you have not</b> read the <a href="/jailbreaking/">jailbreaking lander</a> informational page yet, and are trying to find your jailbreak.<br>Please head over there now, and the warning will clear. <p class="caution"><b>Do NOT expect any support otherwise.</b></p>`
+        `We have detected <b>you have not</b> read the <a href="${baseUrl}jailbreaking/">jailbreaking lander</a> informational page yet, and are trying to find your jailbreak.<br>Please head over there now, and the warning will clear. <p class="caution"><b>Do NOT expect any support otherwise.</b></p>`
     );
 };
 
@@ -193,7 +193,7 @@ let text = document.querySelector("#classification");
 let tip = document.querySelector("#tip"); 
 
 function fillResults() { //This tickles my brain
-    fetch("/jailbreaks.json").then(response => response.json()).then((data) => {
+    fetch(`${baseUrl}jailbreaks.json`).then(response => response.json()).then((data) => {
         const matches = data.filter(jb => {
             if(!jb.models.includes(window.info.model)) return false;
             if(jb.registration && window.info.blacklisted) return false;
@@ -216,9 +216,9 @@ function fillResults() { //This tickles my brain
         let next = document.querySelector(":not(.hidden).card > .buttons > #next");
 
         if(matches.length > 0) {
-            text.innerHTML = `We have determined you should use <b><a href="${matches[0].url}">${matches[0].name}</a></b>!<br/>Please press on a link or click "Finish" to get started.`;
-            
-            let others = []; matches.forEach((match, i) => i === 0 ? "" : others.push(`<a href="${match.url}">${match.name}</a>`));
+            text.innerHTML = `We have determined you should use <b><a href="${baseUrl}${matches[0].url}">${matches[0].name}</a></b>!<br/>Please press on a link or click "Finish" to get started.`;
+
+            let others = []; matches.forEach((match, i) => i === 0 ? "" : others.push(`<a href="${baseUrl}${match.url}">${match.name}</a>`));
             tip.innerHTML = others.length > 0 ? `Alternatively, you can also attempt ${others.join(", ")} if preferred/something went wrong.` : "This is the <i>only</i> jailbreak applicable to this firmware and model combination. Be careful!";
 
             next.onclick = () => { document.location = matches[0].url; };
@@ -231,6 +231,6 @@ function fillResults() { //This tickles my brain
     });
 };
 
-fetch("/models.json").then(response => response.json()).then((data) => {
+fetch(`${baseUrl}models.json`).then(response => response.json()).then((data) => {
     window.kindleModels = data;
 });

--- a/static/nosb/index.html
+++ b/static/nosb/index.html
@@ -6,6 +6,6 @@
 </head>
 <body>
 <h2>Press the L on Bezos's forehead to jailbreak</h2>
-<img src="bezos.jpg" onclick="location.href='/nosb/jb.html'">
+<img src="bezos.jpg" onclick="location.href='./jb.html'">
 </body>
 </html>


### PR DESCRIPTION
A ton of links were simply linking to moved files or sections, so they needed to be fixed. Some of them were linking to sections that no longer exist, so those had to be removed. And the rest has been switched to relative references so the whole site is self-contained.