### PR TITLE
Fix WinterBreak2 post-jailbreak flow to use Legacy stack

### DIFF
--- a/content/jailbreaking/Legacy/post-jailbreak/disable-ota.md
+++ b/content/jailbreaking/Legacy/post-jailbreak/disable-ota.md
@@ -11,6 +11,8 @@ Kindles automatically update when connected to Wi-Fi, which despite a `hotfix`, 
 
 > [!WARNING]
 > You may skip this if you jailbroke using Winterbreak, Springbreak, or Sanctuary. OTA updates have already been blocked for you.
+>
+> **Exception:** If you used **WinterBreak2** and your `winterbreak.log` says `Please Install HOTFIX now`, OTA updates have **not** been blocked for you — you **must** complete this step.
 
 <div id="guide">
     <div class="buttons">
@@ -132,7 +134,7 @@ Kindles automatically update when connected to Wi-Fi, which despite a `hotfix`, 
     </div>
 </div>
 
-<script>new Guide("guide", "#", "Finish");</script>
+<script>new Guide("guide", "./koreader.html", "Installing KOReader");</script>
 
 ## Credits
 

--- a/content/jailbreaking/Legacy/post-jailbreak/koreader.md
+++ b/content/jailbreaking/Legacy/post-jailbreak/koreader.md
@@ -1,0 +1,124 @@
+---
+layout: default
+parent: Post Jailbreak
+title: Installing KOReader
+weight: 4
+---
+
+# Installing KOReader
+
+_KOReader is a document viewer for E Ink devices. Supported formats include EPUB, PDF, DjVu, XPS, CBT, CBZ, FB2, PDB, TXT, HTML, RTF, CHM, DOC, MOBI and ZIP files._
+
+> [!NOTE]
+> Your Kindle must be jailbroken and have MRPI and KUAL installed to be able to run KOReader.
+
+> [!WARNING]
+> This is the **manual** installation method, which is used by the Legacy post-jailbreak stack (KUAL & MRPI). If your jailbreak pre-installed **KPM** instead, use `;kpm install koreader` in the search bar, as detailed in the [What's Next](/jailbreaking/whats-next/index.html) section!
+
+<div id="guide">
+    <div class="buttons">
+        <button id="prev">Previous Step</button>
+        <span id="stepCounter"></span>
+        <button id="next">Next Step</button>
+    </div>
+    <div id="stepwrapper" class="stepwrapper">
+        <div class="step">
+            <h2>Determine your firmware version</h2>
+            <div class="stepContent">
+                <p>Before proceeding, check your Kindle's firmware version by going to:</p>
+                <p><strong>Home → Menu → Settings → Menu → Device Info</strong></p>
+                <p class="highlight">Different firmware versions require different KOReader packages</p>
+            </div>
+        </div>
+        
+<div class="step">
+    <h2>Download KOReader</h2>
+        <div class="stepContent">
+                <p>Download KOReader from the <a href="https://github.com/koreader/koreader/releases" target="_blank">official release page</a></p>
+                <p>Choose the correct package for your Kindle:</p>
+                <div class="version-block">
+                    <p class="version-label">KOReader Packages:</p>
+                    <code>kindle-legacy</code>: K2, DX, K3 (and all variants)
+                    <br/>
+                    <code>kindle</code>: K4, K5, PW1
+                    <br/>
+                    <code>kindlepw2</code>: PW2 and newer models running firmware =< 5.16.2.1.1
+                    <br/>
+                    <code>kindlehf</code>: <b>Any Kindle device</b> running firmware >=5.16.3
+                </div>
+        </div>
+    </div>
+        
+<div class="step">
+            <h2>Alternative Download Method</h2>
+            <div class="stepContent">
+                <div class="version-block">
+                    <p class="version-label">Firmware >=5.16.3:</p>
+                        <a href="https://scriptlets.notmarek.com/" target="_blank">Marek's KOReader Installer (nightly)</a> Download and copy this scriptlet into the <code>/documents</code> folder on your Kindle, run it from your Library and it will automatically download and install KOReader
+                    <p class="note">This alternative method might not work for everyone</p>
+                </div>
+            </div>
+        </div>
+
+<div class="step">
+            <h2>Connect your Kindle to your computer</h2>
+            <div class="stepContent">
+                <p>Plug your Kindle into your PC via USB cable</p>
+                <p>Wait for your computer to recognize the device</p>
+                <p class="highlight">Make sure your Kindle appears as a storage device on your computer</p>
+            </div>
+        </div>
+
+<div class="step">
+            <h2>Install KOReader</h2>
+            <div class="stepContent">
+                <p>Unzip the downloaded file</p>
+                <p>Copy the <code>extensions</code> and <code>koreader</code> folders to the root directory of your Kindle</p>
+                <p class="highlight">When prompted, confirm to merge or replace existing files</p>
+            </div>
+        </div>
+
+<div class="step">
+            <h2>Disconnect and Launch</h2>
+            <div class="stepContent">
+                <p>Safely eject and unplug your Kindle</p>
+                <p>Open KUAL (Kindle Unified Application Launcher)</p>
+                <p>Search for the KOReader menu entry and click on it</p>
+                <div class="version-block">
+                <p class="version-label">KOReader Launch Options</p>
+                    <p>When launching KOReader, you may see three options:</p>
+                    <code>Start KOReader</code>: The designed way to start KOReader
+                    <br/>
+                    <code>Start KOReader (no framework)</code>: Temporarily "kills" the Kindle UI to allocate more resources to KOReader
+                    <br/>
+                    <code>Start KOReader (ASAP)</code>: Skips a couple of checks and starts KOReader as soon as possible
+                    <br/>
+                </div>
+            </div>
+        </div>
+
+<div class="step">
+            <h2>Done</h2>
+            <div class="stepContent">
+                <p>KOReader is now installed on your Kindle!</p>
+                <p>We recommend reading the <a href="https://koreader.rocks/user_guide/" target="_blank">extensive but very helpful guide for KOReader</a></p>
+                <p class="note">
+                    KOReader currently does not support USBMS mode (USB transfer) and will only charge the device, if you want to transfer files you must exit KOReader to do so 
+                </p>
+                <p class="warning">
+                    If KOReader appears in KUAL but doesn't work when clicked, delete both <code>koreader</code> folders, re-download koreader and make sure you're downloading the right package for your Kindle</p>
+            </div>
+        </div>
+    </div>
+    <div class="buttons">
+        <button id="prev">Previous Step</button>
+        <span id="stepCounter"></span>
+        <button id="next">Next Step</button>
+    </div>
+</div>
+
+<script>new Guide("guide", "/jailbreaking/jailbreak-faq.html", "Jailbreak FAQ");</script>
+
+## Credits
+
+- Written by Bundlerocks, re-designed to Fluent Style with ntindle and adapted from the [official KOReader Github installation page](https://github.com/koreader/koreader/wiki/Installation-on-Kindle-devices#err-there-are-four-kindle-packages-to-choose-from-which-do-i-pick)

--- a/content/jailbreaking/Legacy/post-jailbreak/setting-up-a-hotfix/__index.md
+++ b/content/jailbreaking/Legacy/post-jailbreak/setting-up-a-hotfix/__index.md
@@ -15,6 +15,7 @@ A hotfix allows your Kindle's jailbreak to persist after updating. There are two
 > [!WARNING]
 > You may skip this if you jailbroke using Winterbreak, Springbreak, or Sanctuary. The hotfix has already been installed for you.  
 > This is also not necessary for some types of legacy jailbreaks, check the corresponding page.
+> **Exception:** If you used **WinterBreak2** and your `winterbreak.log` says `Please Install HOTFIX now`, you **must** install the hotfix — do not skip this step.
 
 <div id="guide">
     <div class="buttons">

--- a/content/jailbreaking/WinterBreak2/__index.md
+++ b/content/jailbreaking/WinterBreak2/__index.md
@@ -89,11 +89,19 @@ WinterBreak2 is a browser-based jailbreak created by [Scam.Net](https://github.c
             <h2>After Jailbreaking...</h2>
             <div class="stepContent">
                 <div class="tip">
-                    <b>What's Next?</b><br>
-                    Commence to the <a href="../whats-next">What's Next</a> section to read about installing scriptlets, homebrew, and KOReader.<br>Read the <b>whole section</b> thoroughly.
+                    <b>Check Your Log</b><br>
+                    Plug your Kindle back into your computer and open the <code>winterbreak.log</code> file at the root of your Kindle's storage.<br><br>
+                    If it contains <code>Please Install HOTFIX now</code>, your Kindle is on the <b>Legacy post-jailbreak stack</b>, and you <b>must</b> follow the steps below.
                 </div>
                 <div class="caution">
-                    You may now <b>delete</b> any filler files. Updates have been automatically blocked for you.<br><br>
+                    Do <b>not</b> use the <code>;kpm</code> package manager, as it does not apply to this stack. Instead, you must:<br>
+                    1. Install the <a href="/jailbreaking/Legacy/post-jailbreak/setting-up-a-hotfix/">Universal Hotfix</a><br>
+                    2. Install <a href="/jailbreaking/Legacy/post-jailbreak/installing-kual-mrpi/">KUAL &amp; MRPI</a><br>
+                    3. <a href="/jailbreaking/Legacy/post-jailbreak/disable-ota.html">Disable OTA updates</a><br>
+                    4. <a href="/jailbreaking/Legacy/post-jailbreak/koreader.html">Install KOReader manually</a>
+                </div>
+                <div class="caution">
+                    You may now <b>delete</b> any filler files.<br><br>
                     Before you do this, also <b>remove any existing update files with a <code>.bin</code> extension</b>, if they exist in the Kindle's root.
                 </div>
                 <p>Have fun! :)</p>
@@ -106,7 +114,7 @@ WinterBreak2 is a browser-based jailbreak created by [Scam.Net](https://github.c
         <button id="next">Next Step</button>
     </div>
 </div>
-<script>new Guide("guide", "../whats-next", "What's Next?");</script>
+<script>new Guide("guide", "/jailbreaking/Legacy/post-jailbreak/setting-up-a-hotfix/", "Setup a Hotfix");</script>
 
 # Troubleshooting
 

--- a/content/jailbreaking/jailbreak-faq.md
+++ b/content/jailbreaking/jailbreak-faq.md
@@ -220,7 +220,7 @@ This is also the case for the "Collecting Debug Info" message.
 
 You can do one of the following:
 
-- [Install KOReader](https://kindlemodding.org/jailbreaking/post-jailbreak/koreader.html)
+- [Install KOReader](https://kindlemodding.org/jailbreaking/Legacy/post-jailbreak/koreader.html)
 - [Downgrade your Kindle](https://kindlemodding.org/firmware-and-flashing/downgrading/)
 - Download scriptlets:
     - [Marek's Scriplets](https://scriptlets.notmarek.com/)


### PR DESCRIPTION
## Summary

WinterBreak2 was directing users to the **What's Next?** / `;kpm` workflow after jailbreaking, but WinterBreak2 does **not** install KPM. Its `jb.sh` ends with `*** Please Install HOTFIX now ***` and does **not** block OTA updates — so `;kpm update` / `;kpm install koreader` are treated as ordinary Kindle searches, and the only KOReader page listed (the old `/jailbreaking/post-jailbreak/koreader.html`) was deleted during the Legacy reorganisation and 404'd.

## Changes

- **WinterBreak2 page**: replaced the "What's Next" step with a **log-based decision point** — if `winterbreak.log` contains `Please Install HOTFIX now`, the reader is on the **Legacy post-jailbreak stack** and must follow: Universal Hotfix → KUAL & MRPI → Disable OTA → manual KOReader. Explicitly warns **not** to use `;kpm`. Also fixes the stale "updates automatically blocked" claim (false for WB2).
- **Restored `content/jailbreaking/Legacy/post-jailbreak/koreader.md`** (deleted in `2921284`): the manual KOReader guide for the Legacy stack, updated nav weight and links. Fixes the `../koreader.html` link in `installing-kual-mrpi`.
- **`disable-ota.md` / `setting-up-a-hotfix`**: documented the WinterBreak2 exception so these users do not skip the hotfix / OTA blocking.
- **`jailbreak-faq.md`**: fixed the KOReader link pointing at the deleted page.
- Chained the Legacy guides (jailbreak → hotfix → KUAL/MRPI → OTA protection → KOReader) so there are no dead ends.

## Not changed

Jailbreaks that genuinely ship KPM — SpringBreak, AdBreak, Nosebleed, Sanctuary, Vera, WinterBreak — keep their existing What's Next / `;kpm` flow.

## Verification

- Read upstream `KindleModding/WinterBreak2` release `jb.sh` (confirms log lines, hotfix requirement, OTA-restore behaviour).
- KOReader wiki lists WinterBreak2 under the **manual** installation method, not KPM; PW3 @ ≤5.16.2.1.1 uses the **PW2** package (matches restored page).
- `hugo --minify` builds clean (exit 0, no errors); all modified internal links verified against the build output.